### PR TITLE
Handle mysqldump not supporting --column-statistics option

### DIFF
--- a/stashers/mysql.go
+++ b/stashers/mysql.go
@@ -31,7 +31,11 @@ func (m MySql) CreateStash(db *config.DB, dbName string, stashName string) error
 	if err != nil {
 		os.Remove(stashFilePath)
 		if err.Error() == "exit status 2" {
-			return errors.New(fmt.Sprintf("Cannot connect to db '%s'", dbName))
+			return errors.New(fmt.Sprintf("cannot connect to db '%s'", dbName))
+		}
+
+		if err.Error() == "exit status 7" {
+			return errors.New(fmt.Sprintf("mysqldump does not support column-statistics, please upgrade"))
 		}
 
 		return err


### PR DESCRIPTION
Some versions of mysqldump do not support `--column-statistics=0` and will fail.

```
mysqldump -V 
Ver 10.19 Distrib 10.10.2-MariaDB, for osx10.17 (x86_64)
```
Handle this in an ugly if and re-run without the flag.